### PR TITLE
Fixing where Blender complaining on missing ensurepip

### DIFF
--- a/kingpin/animall_toolbar.py
+++ b/kingpin/animall_toolbar.py
@@ -12,8 +12,6 @@ Note: Use full 'AnimAll' plugin if you want full control.
       This light version is only suitable for an imported mesh via the kingpin script
 '''
 
-
-from ensurepip import version
 import bpy
 from bpy.types import (
     Operator,


### PR DESCRIPTION
Importing ensurepip version prevented my Blender to add this plugin. Later code actually doesn't need this at all, so removing it did the job.